### PR TITLE
fix(mister): audio float conversion and 180° rotation support

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -625,12 +625,30 @@ static void audio_driver_flush(audio_driver_state_t *audio_st,
       settings_t *settings   = config_get_ptr();
       if (settings->bools.video_mister_enable && mister_is_connected())
       {
+         // Always convert to int16 for MiSTer (fixes float audio driver issue)
+         unsigned mister_frames = (unsigned)src_data.output_frames;
+         const int16_t *mister_data;
+
+         if (audio_st->flags & AUDIO_FLAG_USE_FLOAT)
+         {
+            // Convert float to int16 for MiSTer
+            convert_float_to_s16(audio_st->output_samples_conv_buf,
+                  (const float*)audio_st->output_samples_buf, mister_frames * 2);
+            mister_data = audio_st->output_samples_conv_buf;
+         }
+         else
+         {
+            mister_data = (const int16_t*)output_data;
+         }
+
+         unsigned mister_bytes = mister_frames * 2 * sizeof(int16_t); // stereo int16
+
          // flush buffer if needed
-         if (audio_st->output_mister_samples + output_frames > AUDIO_BUFFER_FREE_SAMPLES_COUNT)
+         if (audio_st->output_mister_samples + mister_frames * 2 > AUDIO_BUFFER_FREE_SAMPLES_COUNT)
             mister_audio();
 
-         memcpy(&audio_st->output_mister_samples_conv_buf[audio_st->output_mister_samples], output_data, output_frames << 1);
-         audio_st->output_mister_samples += output_frames;
+         memcpy(&audio_st->output_mister_samples_conv_buf[audio_st->output_mister_samples], mister_data, mister_bytes);
+         audio_st->output_mister_samples += mister_frames * 2;
       }
 #endif
 

--- a/gfx/gfx_mister.c
+++ b/gfx/gfx_mister.c
@@ -296,8 +296,12 @@ void mister_draw(video_driver_state_t *video_st, const void *data, unsigned widt
    else switch (rotation)
    {
       case ORIENTATION_NORMAL:
-      case ORIENTATION_FLIPPED:
          c_step = pix_size;
+         r_step = mister_video.interlaced ? 2 : 1;
+         break;
+
+      case ORIENTATION_FLIPPED:
+         c_step = -pix_size;  // Walk backwards for 180° flip
          r_step = mister_video.interlaced ? 2 : 1;
          break;
 
@@ -319,8 +323,11 @@ void mister_draw(video_driver_state_t *video_st, const void *data, unsigned widt
       if (is_hw_rendered)
          c = (mister_video.width * (mister_video.height / r_step - y_start - field - j) + x_start) * pix_size;
 
-      else if (menu_on || !(rotation & 1))
+      else if (menu_on || rotation == ORIENTATION_NORMAL)
          c = ((j + y_start) * mister_video.width + x_start) * pix_size;
+
+      else if (rotation == ORIENTATION_FLIPPED)
+         c = ((mister_video.height - 1 - j - y_start) * mister_video.width + mister_video.width - 1 - x_start) * pix_size;
 
       else if (rotation == ORIENTATION_VERTICAL)
          c = (mister_video.width * (mister_video.height / s_step - y_start - 1) + j + x_start) * pix_size;


### PR DESCRIPTION
## Summary

Two bug fixes for MiSTer/GroovyMister streaming on Linux:

### Audio fix
- When audio driver uses float samples (ALSA, PipeWire, PulseAudio), the raw float bytes were copied directly to the MiSTer buffer instead of being converted to int16, resulting in white noise/static
- Now always converts audio to int16 before sending to MiSTer

### Rotation fix  
- ORIENTATION_FLIPPED (180°) was incorrectly treated the same as ORIENTATION_NORMAL, making video_rotation=2 have no effect
- Now properly implements 180° flip by reversing pixel write order
- Fixes TATE CRT setups where the display appears upside down

## Test plan
- [x] Tested on CachyOS (Arch-based) with PipeWire audio - audio now works correctly
- [x] Tested 180° rotation on TATE CRT - display now flips properly